### PR TITLE
Update requirements.txt to latest version of libs

### DIFF
--- a/floyd_requirements.txt
+++ b/floyd_requirements.txt
@@ -1,6 +1,6 @@
 fire==0.1.3
 nptyping==0.2.0
-numpy==1.17.0
+numpy==1.17.2
 python-crfsuite==0.9.6
 pyyaml==5.1.2
 six==1.12.0

--- a/floyd_requirements.txt
+++ b/floyd_requirements.txt
@@ -1,4 +1,4 @@
-fire==0.2.1
+fire==0.1.3
 nptyping==0.2.0
 numpy==1.17.2
 python-crfsuite==0.9.6

--- a/floyd_requirements.txt
+++ b/floyd_requirements.txt
@@ -1,4 +1,4 @@
-fire==0.1.3
+fire==0.2.1
 nptyping==0.2.0
 numpy==1.17.2
 python-crfsuite==0.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docopt==0.6.2
-fire==0.1.3
+fire==0.2.1
 nptyping==0.2.0
 numpy==1.17.2
 python-crfsuite==0.9.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 docopt==0.6.2
 fire==0.1.3
 nptyping==0.2.0
-numpy==1.17.0
+numpy==1.17.2
 python-crfsuite==0.9.6
 pyyaml==5.1.2
 six==1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docopt==0.6.2
-fire==0.2.1
+fire==0.1.3
 nptyping==0.2.0
 numpy==1.17.2
 python-crfsuite==0.9.6


### PR DESCRIPTION
numpy==1.17.2

Nothing related to bug fixes or features, but more about removing version warnings when using with other libs.

Also depends on this `ssg`'s PR https://github.com/ponrawee/ssg/pull/3 