### PR TITLE
Fix tokenize error for empty string input

### DIFF
--- a/attacut/tokenizer.py
+++ b/attacut/tokenizer.py
@@ -40,6 +40,9 @@ class Tokenizer:
         self.dataset = dataset
 
     def tokenize(self, txt: str, sep="|", device="cpu", pred_threshold=0.5) -> List[str]:
+        if txt == '': #handle empty string input
+            return ['']
+
         tokens, features = self.dataset.make_feature(txt)
 
         inputs = (

--- a/attacut/tokenizer.py
+++ b/attacut/tokenizer.py
@@ -40,8 +40,10 @@ class Tokenizer:
         self.dataset = dataset
 
     def tokenize(self, txt: str, sep="|", device="cpu", pred_threshold=0.5) -> List[str]:
-        if not txt or not isinstance(txt, str):  # handle empty input string
+        if txt == "":  # handle empty input string
             return [""]
+        if not txt or not isinstance(txt, str):  # handle None
+            return []
 
         tokens, features = self.dataset.make_feature(txt)
 

--- a/attacut/tokenizer.py
+++ b/attacut/tokenizer.py
@@ -40,8 +40,8 @@ class Tokenizer:
         self.dataset = dataset
 
     def tokenize(self, txt: str, sep="|", device="cpu", pred_threshold=0.5) -> List[str]:
-        if txt == '': #handle empty string input
-            return ['']
+        if not txt or not isinstance(txt, str):  # handle empty input string
+            return [""]
 
         tokens, features = self.dataset.make_feature(txt)
 


### PR DESCRIPTION
Problem:
```
import attacut
attacut.tokenize("")

# ... RuntimeError: Calculated padded input size per channel: (2). Kernel size: (3). Kernel size can't be greater than actual input size
```

