### PR TITLE
Use PyTorch's DataLoader and enable GPU usage for CLI

### DIFF
--- a/attacut/dataloaders.py
+++ b/attacut/dataloaders.py
@@ -105,7 +105,7 @@ class CharacterSeqDataset(SequenceDataset):
 
         for i, s in enumerate(batch):
             b_feature = s[0][0]
-            total_features = len(b_feature)
+            total_features = b_feature.shape[1]
             features[i, :total_features] = b_feature
             labels[i, :total_features] = s[1]
 
@@ -116,7 +116,7 @@ class CharacterSeqDataset(SequenceDataset):
 
         labels = torch.from_numpy(labels)[perm_idx]
 
-        return inputs, labels
+        return inputs, labels, perm_idx
 
 
 class SyllableCharacterSeqDataset(SequenceDataset):
@@ -194,4 +194,4 @@ class SyllableCharacterSeqDataset(SequenceDataset):
 
         labels = torch.from_numpy(labels)[perm_idx]
 
-        return inputs, labels
+        return inputs, labels, perm_idx

--- a/attacut/dataloaders.py
+++ b/attacut/dataloaders.py
@@ -105,7 +105,7 @@ class CharacterSeqDataset(SequenceDataset):
 
         for i, s in enumerate(batch):
             b_feature = s[0][0]
-            total_features = b_feature.shape[1]
+            total_features = b_feature.shape[0]
             features[i, :total_features] = b_feature
             labels[i, :total_features] = s[1]
 

--- a/attacut/models/__init__.py
+++ b/attacut/models/__init__.py
@@ -10,6 +10,13 @@ from attacut import logger
 log = logger.get_logger(__name__)
 
 
+def get_device():
+    if torch.cuda.is_available():
+        return "cuda"
+    else:
+        return "cpu"
+
+
 class ConvolutionBatchNorm(nn.Module):
     def __init__(self, channels, filters, kernel_size, stride=1, dilation=1):
         super(ConvolutionBatchNorm, self).__init__()

--- a/attacut/tokenizer.py
+++ b/attacut/tokenizer.py
@@ -53,9 +53,9 @@ class Tokenizer:
         )
 
         x, _, _ = self.dataset.prepare_model_inputs(inputs, device=device)
-        logits = torch.sigmoid(self.model(x))
+        probs = torch.sigmoid(self.model(x))
 
-        preds = logits.cpu().detach().numpy() > pred_threshold
+        preds = probs.cpu().detach().numpy() > pred_threshold
 
         words = preprocessing.find_words_from_preds(tokens, preds)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,13 +46,20 @@ Command-Line Interface
     AttaCut: Fast and Reasonably Accurate Word Tokenizer for Thai
 
     Usage:
-    attacut-cli <src> [--dest=<dest>] [--model=<model>]
-    attacut-cli (-h | --help)
+    attacut-cli <src> [--dest=<dest>] [--model=<model>] [--num-cores=<num-cores>] [--batch-size=<batch-size>] [--gpu]
+    attacut-cli [-v | --version]
+    attacut-cli [-h | --help]
+
+    Arguments:
+    <src>             Path to input text file to be tokenized
 
     Options:
     -h --help         Show this screen.
     --model=<model>   Model to be used [default: attacut-sc].
     --dest=<dest>     If not specified, it'll be <src>-tokenized-by-<model>.txt
+    -v --version      Show version
+    --num-cores=<num-cores>  Use multiple-core processing [default: 0]
+    --batch-size=<batch-size>  Batch size [default: 20]
 
 
 High-Level API
@@ -72,6 +79,8 @@ High-Level API
 
 
 AttaCut will be soon integrated into PyThaiNLP's ecosystem. Please see `PyThaiNLP #28 <https://github.com/PyThaiNLP/pythainlp/issues/258>`_ for recent updates
+
+For better efficiency, we recommend using **attacut-cli**. Please consult `our Google Colab tutorial <https://colab.research.google.com/drive/1-JM19BnSMAWaF4aFgb8jcSiISfKr0PyH>` for more detials.
 
 
 .. |travis_ic| image:: https://travis-ci.org/PyThaiNLP/attacut.svg?branch=master

--- a/scripts/attacut-cli
+++ b/scripts/attacut-cli
@@ -3,7 +3,7 @@
 """AttaCut: Fast and Reasonably Accurate Word Tokenizer for Thai
 
 Usage:
-  attacut-cli <src> [--dest=<dest>] [--model=<model>]
+  attacut-cli <src> [--dest=<dest>] [--model=<model>] [--num-cores=<num-cores>] [--batch-size=<batch-size>] [--gpu]
   attacut-cli [-v | --version]
   attacut-cli [-h | --help]
 
@@ -15,23 +15,70 @@ Options:
   --model=<model>   Model to be used [default: attacut-sc].
   --dest=<dest>     If not specified, it'll be <src>-tokenized-by-<model>.txt
   -v --version      Show version
-
+  --num-cores=<num-cores>  Use multiple-core processing [default: 4]
+  --batch-size=<batch-size>  Batch size [default: 20]
 """
 
+import sys
 import os
+from multiprocessing import Pool
 
+import numpy as np
 import torch
+from torch.utils.data import Dataset, DataLoader
 from tqdm import tqdm
 
-from attacut import Tokenizer, __version__, preprocessing, utils
+
+from attacut import Tokenizer, __version__, preprocessing, utils, models
 from docopt import docopt
 
 SEP = "|"
 
-
 def get_argument(dict, name, default):
     v = dict.get(name)
     return v if v is not None else default
+
+class AttaCutCLIDataset(Dataset):
+      def __init__(self, src, tokenizer, device):
+          self.src = src
+          self.total_lines = utils.wc_l(self.src)
+
+          self.tokenizer = tokenizer
+
+          self.device = device
+
+          self.data = []
+          with open(self.src, "r") as fin:
+              for txt in fin:
+                txt = preprocessing.TRAILING_SPACE_RX.sub("", txt)
+
+                tokens, features = self.tokenizer.dataset.make_feature(txt)
+
+                inputs = (
+                    features,
+                    torch.zeros(features[1])  # dummy label when won't need it here
+                )
+
+                x, labels, _= self.tokenizer.dataset.prepare_model_inputs(
+                  inputs, device=self.device
+                )
+
+                self.data.append(((x, labels), tokens))
+
+      def __len__(self):
+          return self.total_lines
+
+      def __getitem__(self, idx):
+          return self.data[idx]
+
+def collate_fn(tokenizer, batch):
+    inputs, tokens = [], []
+
+    for x, t in batch:
+      inputs.append(x)
+      tokens.append(t)
+
+    return tokenizer.dataset.collate_fn(inputs), tokens
 
 
 if __name__ == "__main__":
@@ -39,6 +86,14 @@ if __name__ == "__main__":
 
     src = arguments["<src>"]
     model = arguments["--model"]
+    num_cores = int(arguments["--num-cores"])
+    batch_size = int(arguments["--batch-size"])
+
+    assert num_cores >= 1, "Input given to <num-thread> should greather than or equal one"
+
+    if not src:
+      print(__doc__)
+      sys.exit(0)
 
     # for a custom model, use the last dir's name.
     model_name = model.split("/")[-1]
@@ -57,22 +112,48 @@ if __name__ == "__main__":
     print(f"Output: {dest}")
 
     tokenizer = Tokenizer(model)
+
     total_lines = utils.wc_l(src)
 
+    print(f"Use {num_cores} workers for processing for {total_lines} lines")
+
+    device = "cuda" if arguments["--gpu"] else "cpu"
+    print("device")
+
+    ds = AttaCutCLIDataset(src, tokenizer, device)
+    dataloader = DataLoader(
+      ds,
+      batch_size=batch_size,
+      shuffle=False,
+      num_workers=num_cores, 
+      collate_fn=lambda batch: collate_fn(tokenizer, batch)
+    )
+
+    tokenizer.model.to(device)
+
+
+    results = []
+
     with torch.no_grad(), \
-        open(src, "r") as fin, \
+        tqdm(total=total_lines) as tq, \
         open(dest, "w") as fout:
-        # todo: dataloader generator
-        # todo: tokenize by batch and write results
-        for line in tqdm(fin, total=total_lines):
+          for batch in dataloader:
+              (x, labels, perm_idx), tokens = batch
+              probs = tokenizer.model(x)
 
-            line = preprocessing.TRAILING_SPACE_RX.sub("", line)
+              preds = probs.cpu().detach().numpy() > 0.5
+              max_seq = x[1].max().cpu().detach().numpy()
 
-            if not line:
-                fout.write("\n")
-                continue
+              perm_idx = perm_idx.cpu().detach()
+              preds = preds.reshape((-1, max_seq))
 
-            words = tokenizer.tokenize(line)
-            tokenized_line = SEP.join(words)
 
-            fout.write(f"{tokenized_line}\n")
+              for ori_ix, after_sorting_ix in enumerate(np.argsort(perm_idx)):
+                  pred = preds[after_sorting_ix, :]
+                  token = tokens[ori_ix]
+
+
+                  words = preprocessing.find_words_from_preds(token, pred)
+                  fout.write("%s\n" % SEP.join(words))
+
+              tq.update(n=preds.shape[0])

--- a/scripts/attacut-cli
+++ b/scripts/attacut-cli
@@ -124,9 +124,10 @@ if __name__ == "__main__":
 
     total_lines = utils.wc_l(src)
 
+    torch.set_num_threads(num_cores)
 
     device = "cuda" if arguments["--gpu"] else "cpu"
-    print(f"Use {num_cores} workers for processing for {total_lines} lines")
+    print(f"Use {num_cores} cores for processing for {total_lines} lines")
     print(f"device={device}")
 
     ds = AttaCutCLIDataset(src, tokenizer, device)
@@ -134,7 +135,7 @@ if __name__ == "__main__":
       ds,
       batch_size=batch_size,
       shuffle=False,
-      num_workers=num_cores, 
+      num_workers=0, # only use main process
       collate_fn=lambda batch: collate_fn(tokenizer, batch, device)
     )
 

--- a/scripts/attacut-cli
+++ b/scripts/attacut-cli
@@ -66,11 +66,13 @@ class AttaCutCLIDataset(Dataset):
                     torch.zeros(features[1])  # dummy label when won't need it here
                 )
 
-                x, labels, _= self.tokenizer.dataset.prepare_model_inputs(
+                (x, seq), labels, _= self.tokenizer.dataset.prepare_model_inputs(
                   inputs,
                 )
 
-                self.data.append(((x, labels), tokens))
+                x = torch.squeeze(x)
+
+                self.data.append((((x, seq), labels), tokens))
 
       def __len__(self):
           return self.total_lines
@@ -98,7 +100,7 @@ if __name__ == "__main__":
     num_cores = int(arguments["--num-cores"])
     batch_size = int(arguments["--batch-size"])
 
-    assert num_cores >= 0, "Input given to <num-thread> should greather than or equal zero"
+    assert num_cores >= 1, "Input given to <num-thread> should greather than or equal one"
 
     if not src:
       print(__doc__)

--- a/scripts/attacut-cli
+++ b/scripts/attacut-cli
@@ -21,7 +21,6 @@ Options:
 
 import sys
 import os
-from multiprocessing import Pool
 
 import numpy as np
 import torch
@@ -100,7 +99,7 @@ if __name__ == "__main__":
     num_cores = int(arguments["--num-cores"])
     batch_size = int(arguments["--batch-size"])
 
-    assert num_cores >= 1, "Input given to <num-thread> should greather than or equal one"
+    assert num_cores >= 0, "Input given to <num-thread> should greather than or equal one"
 
     if not src:
       print(__doc__)
@@ -126,10 +125,13 @@ if __name__ == "__main__":
 
     total_lines = utils.wc_l(src)
 
-    torch.set_num_threads(num_cores)
-
     device = "cuda" if arguments["--gpu"] else "cpu"
-    print(f"Use {num_cores} cores for processing for {total_lines} lines")
+
+    if num_cores == 0:
+        print(f"Use main process processing for {total_lines} lines")
+    else:
+        print(f"Use {num_cores} cores for processing for {total_lines} lines")
+
     print(f"device={device}")
 
     ds = AttaCutCLIDataset(src, tokenizer, device)

--- a/scripts/attacut-cli
+++ b/scripts/attacut-cli
@@ -15,7 +15,7 @@ Options:
   --model=<model>   Model to be used [default: attacut-sc].
   --dest=<dest>     If not specified, it'll be <src>-tokenized-by-<model>.txt
   -v --version      Show version
-  --num-cores=<num-cores>  Use multiple-core processing [default: 4]
+  --num-cores=<num-cores>  Use multiple-core processing [default: 0]
   --batch-size=<batch-size>  Batch size [default: 20]
 """
 
@@ -78,7 +78,7 @@ class AttaCutCLIDataset(Dataset):
       def __getitem__(self, idx):
           return self.data[idx]
 
-def collate_fn(tokenizer, batch, devicw):
+def collate_fn(tokenizer, batch, device):
     inputs, tokens = [], []
 
     for x, t in batch:
@@ -87,8 +87,7 @@ def collate_fn(tokenizer, batch, devicw):
 
     (x, seq), labels, perm_idx = tokenizer.dataset.collate_fn(inputs)
 
-    return ((x.to(device), seq.to(device)), labels.to(device), perm_idx) \
-      , tokens
+    return ((x.to(device), seq.to(device)), labels, perm_idx), tokens
 
 
 if __name__ == "__main__":
@@ -99,7 +98,7 @@ if __name__ == "__main__":
     num_cores = int(arguments["--num-cores"])
     batch_size = int(arguments["--batch-size"])
 
-    assert num_cores >= 1, "Input given to <num-thread> should greather than or equal one"
+    assert num_cores >= 0, "Input given to <num-thread> should greather than or equal zero"
 
     if not src:
       print(__doc__)
@@ -140,7 +139,6 @@ if __name__ == "__main__":
     )
 
     tokenizer.model.to(device)
-
 
     results = []
 

--- a/scripts/attacut-cli
+++ b/scripts/attacut-cli
@@ -60,7 +60,7 @@ class AttaCutCLIDataset(Dataset):
                 )
 
                 x, labels, _= self.tokenizer.dataset.prepare_model_inputs(
-                  inputs, device=self.device
+                  inputs,
                 )
 
                 self.data.append(((x, labels), tokens))
@@ -71,14 +71,17 @@ class AttaCutCLIDataset(Dataset):
       def __getitem__(self, idx):
           return self.data[idx]
 
-def collate_fn(tokenizer, batch):
+def collate_fn(tokenizer, batch, devicw):
     inputs, tokens = [], []
 
     for x, t in batch:
       inputs.append(x)
       tokens.append(t)
 
-    return tokenizer.dataset.collate_fn(inputs), tokens
+    (x, seq), labels, perm_idx = tokenizer.dataset.collate_fn(inputs)
+
+    return ((x.to(device), seq.to(device)), labels.to(device), perm_idx) \
+      , tokens
 
 
 if __name__ == "__main__":
@@ -115,10 +118,10 @@ if __name__ == "__main__":
 
     total_lines = utils.wc_l(src)
 
-    print(f"Use {num_cores} workers for processing for {total_lines} lines")
 
     device = "cuda" if arguments["--gpu"] else "cpu"
-    print("device")
+    print(f"Use {num_cores} workers for processing for {total_lines} lines")
+    print(f"device={device}")
 
     ds = AttaCutCLIDataset(src, tokenizer, device)
     dataloader = DataLoader(
@@ -126,7 +129,7 @@ if __name__ == "__main__":
       batch_size=batch_size,
       shuffle=False,
       num_workers=num_cores, 
-      collate_fn=lambda batch: collate_fn(tokenizer, batch)
+      collate_fn=lambda batch: collate_fn(tokenizer, batch, device)
     )
 
     tokenizer.model.to(device)

--- a/scripts/attacut-cli
+++ b/scripts/attacut-cli
@@ -32,6 +32,13 @@ from tqdm import tqdm
 from attacut import Tokenizer, __version__, preprocessing, utils, models
 from docopt import docopt
 
+# from https://github.com/pytorch/pytorch/issues/1494#issuecomment-305993854
+from multiprocessing import set_start_method
+try:
+    set_start_method('spawn')
+except RuntimeError:
+    pass
+
 SEP = "|"
 
 def get_argument(dict, name, default):

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -66,9 +66,9 @@ def do_iterate(model, generator, device,
     metrics = _create_metrics()
 
     for _, batch in enumerate(generator):
-        inputs, perm_ix = batch
+        (x, seq), labels, perm_ix = batch
         xd, yd, total_batch_preds = generator.dataset.prepare_model_inputs(
-            inputs, device
+            ((x, seq), labels), device
         )
 
         if optimizer:

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -15,14 +15,6 @@ from torch.utils import data
 from attacut import dataloaders as dl
 from attacut import evaluation, models, utils
 
-
-def get_device():
-    if torch.cuda.is_available():
-        return "cuda"
-    else:
-        return "cpu"
-
-
 def _create_metrics(metrics=["true_pos", "false_pos", "false_neg"]):
     return dict(zip(metrics, [0]*len(metrics)))
 
@@ -73,7 +65,8 @@ def do_iterate(model, generator, device,
     total_loss, total_preds = 0, 0
     metrics = _create_metrics()
 
-    for _, inputs in enumerate(generator):
+    for _, batch in enumerate(generator):
+        inputs, perm_ix = batch
         xd, yd, total_batch_preds = generator.dataset.prepare_model_inputs(
             inputs, device
         )
@@ -149,7 +142,7 @@ def main(
     # only required
     data_config = training_set.setup_featurizer("%s/dictionary" % data_dir)
 
-    device = get_device()
+    device = models.get_device()
     print("Using device: %s" % device)
 
     params = {}


### PR DESCRIPTION
# Benchmark

Current version can be installed using
```
pip install --upgrade git+git://github.com/pythainlp/attacut.git@batch-processing
```

**Test File:** [subset-of-BEST.txt](https://gist.github.com/heytitle/696e908a0d59850e1374c5f823010e3d/raw/02744055414c748e143ca2d862997e59f25a9bcf/gistfile1.txt)
```
# statistics: total lines, characters
wc -l -m subset-of-BEST.txt
13942 2029230 best-val.txt
```

## Results 
Remarks:
- 🥇is the best configuration for each model.
- *Total Execution Time* is the value is the command `time`'s `real`.


### Environment: aws's P2 instance (1 Tesla K80, 4 vCPUs)

|Model| Option | Total Execution Time  | Total Tokenization Time (first → last lines) |  iterations/sec |
|:---:|:--------|:----:|:-------:|:-------:|
|AttaCut-C|--gpu --batch-size=1    --num-cores=1|28s|22s |612| 
||--gpu --batch-size=100 --num-cores=1|15s🥇|9s|1399| 
||--gpu --batch-size=200 --num-cores=1|16s|10s|1308| 
|AttaCut-SC|--gpu --batch-size=1    --num-cores=1|1m18s| 26s | 521| 
||--gpu --batch-size=100 --num-cores=1|58s|7s|1857| 
||--gpu --batch-size=200 --num-cores=1**|58s🥇|6s|2014| 

### Environment: [Colab](https://colab.research.google.com/drive/1EFNDgYf4vFnK83LSGLC4FPvGPOgAH3v1)

#### without CPU
|Model| Option | Total Execution Time | Total Tokenization Time (first → last lines) |  iterations/sec |
|:---:|:--------:|:----:|:-------:|:-------:|
|AttaCut-C|--batch-size=1    --num-cores=1|1m5s🥇|59s |234| 
||--batch-size=100 --num-cores=1|1m27s|1m24s|165| 
||--batch-size=200 --num-cores=1|1m37|1m34s|147| 
|AttaCut-SC|--batch-size=1    --num-cores=1|1m14s| 36s | 381| 
||--batch-size=100 --num-cores=1|1m13s🥇|36s|378| 
||--batch-size=200 --num-cores=1|1m17s|40s|346| 

#### with GPU
|Model| Option | Total Execution Time  | Total Tokenization Time (first → last lines) |  iterations/sec |
|:---:|:--------:|:----:|:-------:|:-------:|
|AttaCut-C|--gpu --batch-size=1    --num-cores=1|31s|19s |714| 
||--gpu --batch-size=100 --num-cores=1|12s🥇|6s|2083| 
||--gpu --batch-size=200 --num-cores=1|13s|7s|1855| 
|AttaCut-SC|--gpu --batch-size=1    --num-cores=1|1m2s| 23s | 598| 
||--gpu --batch-size=100 --num-cores=1|43s🥇|5s|2780| 
||--gpu --batch-size=200 --num-cores=1|44s|5s|2734| 



### Environment: aws's m5.4xlarge

|Model| Option | Total Execution Time  | Total Tokenization Time (first → last lines) |  iterations/sec |
|:---:|:--------|:----:|:-------:|:-------:|
|AttaCut-C| --batch-size=1    --num-cores=1|50s|47s |292| 
||--batch-size=1 --num-cores=5|37s|35s🥇|397| 
||--batch-size=1000 --num-cores=5|1m8s|1m5s|212| 
||--batch-size=1 --num-cores=10|50s|47s|292| 
|AttaCut-SC|--batch-size=1    --num-cores=1|1m10s| 30s | 457| 
||--batch-size=100 --num-cores=1|1m13s|33s|414| 
||--batch-size=200 --num-cores=1|1m21s|40s|340| 
||--batch-size=1 --num-cores=10|1m9s|28s 🥇|484| 
||--batch-size=1 --num-cores=15|1m13s|33s|416| 