### PR TITLE
Fix type issues and short messages breaking inference

### DIFF
--- a/attacut/dataloaders.py
+++ b/attacut/dataloaders.py
@@ -175,7 +175,7 @@ class SyllableCharacterSeqDataset(SequenceDataset):
     def collate_fn(batch):
         total_samples = len(batch)
 
-        seq_lengths = np.array(list(map(lambda x: x[0][1], batch)))
+        seq_lengths = np.array(list(map(lambda x: x[0][1], batch)), dtype=np.int64)
         max_length = np.max(seq_lengths)
 
         features = np.zeros((total_samples, 2, max_length), dtype=np.int64)

--- a/scripts/attacut-cli
+++ b/scripts/attacut-cli
@@ -165,8 +165,10 @@ if __name__ == "__main__":
                   pred = preds[after_sorting_ix, :]
                   token = tokens[ori_ix]
 
-
-                  words = preprocessing.find_words_from_preds(token, pred)
+                  if len(token) != 0:
+                      words = preprocessing.find_words_from_preds(token, pred)
+                  else:
+                      words = ""
                   fout.write("%s\n" % SEP.join(words))
 
               tq.update(n=preds.shape[0])


### PR DESCRIPTION
I could not run the attacut-cli tool with gpu inference without specifying a type in line 178 of attact/dataloaders.py

Additionally, for my application of tokenizing short messages (tweets), some short messages created zero length tokens and so a words could not be retrieved. I added a simple if-else check to ensure a short message does not break the tokenization of many messags / lines. 